### PR TITLE
fix(mermaid-server): patch path traversal and config security bypass

### DIFF
--- a/packages/mermaid-server/src/renderer/mermaid-bridge.ts
+++ b/packages/mermaid-server/src/renderer/mermaid-bridge.ts
@@ -23,6 +23,16 @@ interface MermaidModule {
   };
 }
 
+const BLOCKED_CONFIG_KEYS = ['securityLevel', 'secure', 'maxTextSize', 'logLevel', 'startOnLoad'];
+
+function sanitizeConfig(config: MermaidConfig): MermaidConfig {
+  const sanitized = { ...config };
+  for (const key of BLOCKED_CONFIG_KEYS) {
+    delete (sanitized as Record<string, unknown>)[key];
+  }
+  return sanitized;
+}
+
 let renderCounter = 0;
 
 export class MermaidBridge {
@@ -77,7 +87,7 @@ export class MermaidBridge {
         const mermaid = this.getMermaid();
         try {
           if (config) {
-            mermaid.initialize({ ...this.defaultConfig, ...config });
+            mermaid.initialize({ ...this.defaultConfig, ...sanitizeConfig(config) });
           }
           const result = await mermaid.parse(text);
           return result;
@@ -98,7 +108,7 @@ export class MermaidBridge {
         const id = `mermaid-server-${++renderCounter}`;
         try {
           if (config) {
-            mermaid.initialize({ ...this.defaultConfig, ...config });
+            mermaid.initialize({ ...this.defaultConfig, ...sanitizeConfig(config) });
           }
           const result = await mermaid.render(id, text);
           return {

--- a/packages/mermaid-server/src/storage/store.ts
+++ b/packages/mermaid-server/src/storage/store.ts
@@ -5,6 +5,14 @@ import { randomUUID } from 'node:crypto';
 const STAGES = ['input', 'staged', 'output', 'archive'] as const;
 type Stage = (typeof STAGES)[number];
 
+const UUID_RE = /^[\da-f]{8}(?:-[\da-f]{4}){3}-[\da-f]{12}$/i;
+
+function validateJobId(jobId: string): void {
+  if (!UUID_RE.test(jobId)) {
+    throw new Error(`Invalid job ID format: ${jobId}`);
+  }
+}
+
 interface JobMetadata {
   createdAt: string;
   stage: Stage;
@@ -42,22 +50,26 @@ export class FileStore {
   }
 
   async writeOutput(jobId: string, filename: string, content: string | Buffer): Promise<void> {
+    validateJobId(jobId);
     const stage = await this.getJobStage(jobId);
     const jobDir = join(this.baseDir, stage, jobId);
     await writeFile(join(jobDir, filename), content);
   }
 
   async readJobFile(jobId: string, stage: Stage, filename: string): Promise<string> {
+    validateJobId(jobId);
     return readFile(join(this.baseDir, stage, jobId, filename), 'utf-8');
   }
 
   async readMetadata(jobId: string): Promise<JobMetadata> {
+    validateJobId(jobId);
     const stage = await this.getJobStage(jobId);
     const raw = await readFile(join(this.baseDir, stage, jobId, 'metadata.json'), 'utf-8');
     return JSON.parse(raw);
   }
 
   async getJobStage(jobId: string): Promise<Stage> {
+    validateJobId(jobId);
     for (const stage of STAGES) {
       try {
         await stat(join(this.baseDir, stage, jobId));
@@ -70,6 +82,7 @@ export class FileStore {
   }
 
   async moveToStage(jobId: string, target: Stage): Promise<void> {
+    validateJobId(jobId);
     const current = await this.getJobStage(jobId);
     if (current === target) {
       return;

--- a/packages/mermaid-server/test/integration/jobs.test.ts
+++ b/packages/mermaid-server/test/integration/jobs.test.ts
@@ -80,7 +80,15 @@ describe('Job endpoints', () => {
   it('returns 404 for nonexistent job', async () => {
     const res = await app.inject({
       method: 'GET',
-      url: '/api/v1/jobs/nonexistent-id',
+      url: '/api/v1/jobs/00000000-0000-0000-0000-000000000000',
+    });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it('rejects path traversal in job ID', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/v1/jobs/../../etc/passwd',
     });
     expect(res.statusCode).toBe(404);
   });


### PR DESCRIPTION
## Summary

- **C-1 Path Traversal:** Validate all `jobId` parameters as UUIDs in `FileStore` to prevent directory traversal via crafted job IDs (e.g. `../../etc/passwd`)
- **C-2 Config Security Bypass:** Sanitize user-supplied mermaid config to block overriding `securityLevel`, `logLevel`, `maxTextSize`, and other sensitive keys that could disable DOMPurify sanitization

## Test plan

- [x] All 71 existing tests pass
- [x] New test: path traversal in job ID returns 404
- [x] Updated test: nonexistent job uses valid UUID format
- [x] ESLint + Prettier pass via lint-staged

🤖 Generated with [Claude Code](https://claude.com/claude-code)